### PR TITLE
"Use current player position as preview" Button not working

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
@@ -202,17 +202,19 @@ pimcore.asset.video = Class.create(pimcore.asset.asset, {
                             try {
                                 this.previewImagePanel.getComponent("inner").getComponent("assetPath").setValue("");
 
+                                var time = window[this.previewFrameId].document.getElementById("video").currentTime;
+                                var date = new Date();
+                                var cmp = Ext.getCmp("pimcore_asset_video_imagepreview_" + this.id);
+
                                 var url = Routing.generate('pimcore_admin_asset_getvideothumbnail', {
                                     id: this.id,
                                     width: 265,
                                     aspectratio: true,
+                                    time: time,
                                     settime: true,
                                     '_dc': date.getTime()
                                 });
 
-                                var time = window[this.previewFrameId].document.getElementById("video").currentTime;
-                                var date = new Date();
-                                var cmp = Ext.getCmp("pimcore_asset_video_imagepreview_" + this.id);
                                 cmp.update('<img class="pimcore_video_preview_image" align="center" src="'+url+'" />');
 
                             } catch (e) {


### PR DESCRIPTION
"Use current player position as preview" button now is working again

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Rearranged video.js

## Additional info  
Can be Reproduced on https://demo.pimcore.fun/
### Expected behavior
Videothumbnail should be set when clicking on "Use current player position as preview" button.
### Actual behavior
Nothing happens, but the browser console logs error: 
`TypeError: Cannot read property 'getTime' of undefined`
### Steps to reproduce
Upload Video, try to set thumbnail
